### PR TITLE
Use billiard instead of multiprocessing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,17 @@
 language: python
-python: 3.5
+python:
+    - 3.6
+    - 3.7
+    - 3.8
 env:
   global:
     LO_VERSION=5.1.1.3
     LO_PATH=/opt/libreoffice5.1/program
-  matrix:
-    - TOXENV=py27-django18
-    - TOXENV=py27-django19
-    - TOXENV=py27-django110
-    - TOXENV=py34-django18
-    - TOXENV=py34-django19
-    - TOXENV=py34-django110
-    - TOXENV=flake8
-install: pip install -U tox
+
+install: pip install -U tox-travis
+
+# Setup Libre Office
 before_install:
   - sudo bash ci/linux.sh
 sudo: required
-script: tox -e ${TOXENV}
-deploy:
-  provider: pypi
-  distributions: sdist bdist_wheel
-  password:
-    secure: "M6mzV77Lp1YkqrWquW3BIwZxe+mF3pnxxV/eFlG/lu6gSEqqnNIGI4l8r/oGxJtVDXKAtALBBaZLJeLnwHvgtsWfkM8T8+9O5KUgAwC9XzIK5QZzFy9M/5O9q1S/z8Soh0jQMiJ8LfHiHBlMkB+f0Yjpd+LDjn/csUbucPYL0qy8sfDKkEHQxR+7N47ncJk2uKAZc5gKZRv6fxZT1SoD5zFlLGuTWGKMJh5PJpG/+enLrkTr6GntSYyY00+EiS0wuQq7N6ymlaN4nPf7vRoR/JaDGQ3LaAaDnwVFNC8cCQlTQP0gx/tcnUYwUmxfP4Ij1kZvfr+bYbEvnn4TA0g1cwap3eXMi6gkwgIh9A2NUS1SmkuhQRvgEXFaIFLyd+c1K8E/+QefI7mB+EG2EyuWo6iEJBiLiehWc+O1PuPkpak3FmZ0ayrK6AOdI0ZQ2rMPwb/Pms09v9r9qcTMLS8DIMH5P5tTmrI/4pG9nMpbhIUWkaWcuO+kSBqUGlqzEkzoPFOePUoxWXN6EAc6s5g/ndF618759vaQegJwLRhsptvHgRdyLNEn8175OBfKu20B2JA4EHDGp/O95Kla2N/U1ycO7xHkMsoPynpvvIs6LWU8tnRxeciVGoCRNWGLgKK7Nz13omiRqfuZrNFCaoV/zMF2QOWrwUG03zWZ0Vi7mHU="
-  user: inductor
-  on:
-    condition: $TOXENV == py34-django19
-    repo: kiawin/templated-docs
-    tags: true
+script: tox --recreate && tox

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -3,7 +3,7 @@ bumpversion==0.5.3
 wheel==0.29.0
 watchdog==0.8.3
 flake8==3.7.9
-tox==3.14.1
+tox==3.15.1
 coverage==4.1
 Sphinx>=1.4,<1.5
 cryptography==2.3.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.3
+current_version = 0.3.4
 commit = True
 tag = True
 tag_name = {new_version}

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ with open('HISTORY.rst') as history_file:
 requirements = [
     'pylokit==0.8.1',
     'django>=1.8,<1.12',
+    'billiard>=3.5.0.2,<3.6.0',
 ]
 
 test_requirements = [
@@ -22,7 +23,7 @@ test_requirements = [
 
 setup(
     name='jpt-templated-docs',
-    version='0.3.3',
+    version='0.3.4',
     description=('Generate PDF, MS Word and Excel documents from templates '
                  'in Django.'),
     long_description=readme + '\n\n' + history,

--- a/templated_docs/__init__.py
+++ b/templated_docs/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-import multiprocessing
+import billiard as multiprocessing
 import os.path
 import re
 from tempfile import NamedTemporaryFile
@@ -24,7 +24,7 @@ from pylokit import Office
 import logging
 log = logging.getLogger(__name__)
 
-__version__ = '0.3.3'
+__version__ = '0.3.4'
 
 
 IMAGES_CONTEXT_KEY = '_templated_docs_imgs'

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,11 @@
 [tox]
-envlist = py{27,34}-django{18,19,110,111}, flake8
+envlist = py3{6,7,8}, django111, django2{2}, django3{0}, flake8
+
+[travis]
+python =
+    3.6: py36
+    3.7: py37
+    3.8: py38
 
 [testenv:flake8]
 deps=flake8
@@ -9,9 +15,9 @@ max-line-length=120
 [testenv]
 passenv = LO_PATH
 deps =
-    django18: Django>=1.8,<1.9
-    django19: Django>=1.9,<1.10
-    django110: Django>=1.10,<1.11
     django111: Django>=1.11,<1.12
-commands = python tests/manage.py test
+    django22: Django>=2.2,<2.3
+    django30: Django>=3.0,<3.1
+commands =
+    python tests/manage.py test
     python example/manage.py check


### PR DESCRIPTION
**Problem**
Multiprocessing lib is causing this library to be unusable in celery
environment, due to celery worker daemon process can't spawn another
child.
While spawning another child is important, because opening
pylokit.Office more than once can cause system exit 77 / 139.

**Solution**
Replace multiprocessing with billiard since billiard is supported to run on celery and will still run outside of celery worker.

**Reference**
https://github.com/kiawin/templated-docs/pull/3