### PR TITLE
Fix Django 2.2.13 get template sources

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open('HISTORY.rst') as history_file:
 
 requirements = [
     'pylokit==0.8.1',
-    'django>=1.8,<1.12',
+    'django>=1.8,<=2.2.13',
     'billiard>=3.5.0.2,<3.6.0',
 ]
 

--- a/templated_docs/__init__.py
+++ b/templated_docs/__init__.py
@@ -70,7 +70,7 @@ def find_template_file(template_name):
     load a template in memory, because we'll deal with it ourselves.
     """
     for loader in _get_template_loaders():
-        for origin in loader.get_template_sources(template_name, None):
+        for origin in loader.get_template_sources(template_name):
             path = getattr(origin, 'name', origin)  # Django <1.9 compatibility
             if os.path.exists(path):
                 return path


### PR DESCRIPTION
Fix get_template_sources to support Django 2.2.13
Refer: https://github.com/alexmorozov/templated-docs/pull/27/files