### PR TITLE
Fixed get_template_sources

### DIFF
--- a/example/example/settings.py
+++ b/example/example/settings.py
@@ -46,7 +46,7 @@ INSTALLED_APPS = [
     'invoices',
 ]
 
-MIDDLEWARE_CLASSES = [
+MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open('HISTORY.rst') as history_file:
 
 requirements = [
     'pylokit==0.8.1',
-    'django>=1.8,<=2.2.13',
+    'django<3.0.0',
     'billiard>=3.5.0.2,<3.6.0',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open('HISTORY.rst') as history_file:
 
 requirements = [
     'pylokit==0.8.1',
-    'django>=1.8,<1.12',
+    'django>=1.8,<=2.2.13',
     'billiard>=3.5.0.2,<3.6.0',
 ]
 

--- a/templated_docs/__init__.py
+++ b/templated_docs/__init__.py
@@ -70,7 +70,7 @@ def find_template_file(template_name):
     load a template in memory, because we'll deal with it ourselves.
     """
     for loader in _get_template_loaders():
-        for origin in loader.get_template_sources(template_name, None):
+        for origin in loader.get_template_sources(template_name):
             path = getattr(origin, 'name', origin)  # Django <1.9 compatibility
             if os.path.exists(path):
                 return path

--- a/tests/test_project/settings.py
+++ b/tests/test_project/settings.py
@@ -45,7 +45,7 @@ INSTALLED_APPS = [
     'test_app',
 ]
 
-MIDDLEWARE_CLASSES = [
+MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',


### PR DESCRIPTION
Fixed `get_template_sources` to be compatible with Django 2.2.13
Refer: https://github.com/alexmorozov/templated-docs/pull/27/files